### PR TITLE
Add tiff unix

### DIFF
--- a/src/unix/dune
+++ b/src/unix/dune
@@ -1,0 +1,8 @@
+(library
+ (name tiff_unix)
+ (foreign_stubs
+  (language c)
+  (flags :standard -D_LARGEFILE64_SOURCE)
+  (names tiff_unix_stubs))
+ (public_name tiff.unix)
+ (libraries tiff unix))

--- a/src/unix/tiff_unix.ml
+++ b/src/unix/tiff_unix.ml
@@ -1,0 +1,11 @@
+external preadv : Unix.file_descr -> Cstruct.t array -> Optint.Int63.t -> int
+  = "caml_tiff_preadv"
+
+let of_fd (fd : Unix.file_descr) : Tiff.File.ro =
+ fun ~file_offset bufs ->
+  let _ : int = preadv fd (Array.of_list bufs) file_offset in
+  ()
+
+let with_open_in ?(open_flags = [ Unix.O_RDONLY; Unix.O_CLOEXEC ]) s fn =
+  let fd = Unix.openfile s open_flags 0 in
+  Fun.protect ~finally:(fun () -> Unix.close fd) (fun () -> fn (of_fd fd))

--- a/src/unix/tiff_unix.mli
+++ b/src/unix/tiff_unix.mli
@@ -1,0 +1,12 @@
+val of_fd : Unix.file_descr -> Tiff.File.ro
+(** Creates a readable file abstraction from an {e open} file descriptor.
+
+    The user is tasked with ensuring the file descriptor is kept open and valid.
+*)
+
+val with_open_in :
+  ?open_flags:Unix.open_flag list -> string -> (Tiff.File.ro -> 'a) -> 'a
+(** [with_open_in path fn] opens [path] as a read-only file and the
+    close-on-exec flag set pass the {! Tiff.File.ro} to [fn]. The
+    {! Tiff.File.ro} is only valid for the scope of [fn] after which the
+    underlying file will be closed. *)

--- a/src/unix/tiff_unix_stubs.c
+++ b/src/unix/tiff_unix_stubs.c
@@ -1,0 +1,97 @@
+/*
+
+From Eio.
+
+Copyright (C) 2021 Anil Madhavapeddy  
+Copyright (C) 2022 Thomas Leonard
+
+Permission to use, copy, modify, and distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+THIS SOFTWARE. */
+#define _FILE_OFFSET_BITS 64
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#ifdef __linux__
+#if __GLIBC__ > 2 || __GLIBC_MINOR__ > 24
+#include <sys/random.h>
+#else
+#include <sys/syscall.h>
+#endif
+#endif
+#include <sys/uio.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdlib.h>
+#include <dirent.h>
+
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/unixsupport.h>
+#include <caml/bigarray.h>
+#include <caml/socketaddr.h>
+#include <caml/custom.h>
+#include <caml/fail.h>
+
+#ifdef ARCH_SIXTYFOUR
+#define Int63_val(v) Long_val(v)
+#define caml_copy_int63(v) Val_long(v)
+#else
+#define Int63_val(v) (Int64_val(v)) >> 1
+#define caml_copy_int63(v) caml_copy_int64(v << 1)
+#endif
+
+static void caml_stat_free_preserving_errno(void *ptr) {
+  int saved = errno;
+  caml_stat_free(ptr);
+  errno = saved;
+}
+
+/* Allocates an array of C iovecs using the cstructs in the array [v_bufs]. */
+static struct iovec *alloc_iov(value v_bufs) {
+  struct iovec *iov;
+  int n_bufs = Wosize_val(v_bufs);
+
+  if (n_bufs == 0) return NULL;
+  iov = caml_stat_calloc_noexc(n_bufs, sizeof(struct iovec));
+  if (iov == NULL)
+    caml_raise_out_of_memory();
+
+  for (int i = 0; i < n_bufs; i++) {
+    value v_cs = Field(v_bufs, i);
+    value v_ba = Field(v_cs, 0);
+    value v_off = Field(v_cs, 1);
+    value v_len = Field(v_cs, 2);
+    iov[i].iov_base = (uint8_t *)Caml_ba_data_val(v_ba) + Long_val(v_off);
+    iov[i].iov_len = Long_val(v_len);
+  }
+  return iov;
+}
+
+CAMLprim value caml_tiff_preadv(value v_fd, value v_bufs, value v_offset) {
+  CAMLparam2(v_bufs, v_offset);
+  ssize_t r;
+  int n_bufs = Wosize_val(v_bufs);
+  struct iovec *iov;
+  off_t offset = Int63_val(v_offset);
+
+  iov = alloc_iov(v_bufs);
+  caml_enter_blocking_section();
+  r = preadv(Int_val(v_fd), iov, n_bufs, offset);
+  caml_leave_blocking_section();
+  caml_stat_free_preserving_errno(iov);
+  if (r < 0) uerror("preadv", Nothing);
+
+  CAMLreturn(Val_long(r));
+}

--- a/test/dune
+++ b/test/dune
@@ -1,7 +1,7 @@
 (executables
  (names test_tiff test_geotiff)
  (modules test_tiff test_geotiff)
- (libraries tiff eio_main ounit2 owl-base))
+ (libraries tiff tiff.unix eio_main ounit2 owl-base))
 
 (rule
  (alias runtest)

--- a/test/test_tiff.ml
+++ b/test/test_tiff.ml
@@ -53,9 +53,8 @@ let test_read_multi_plane_fails_when_without_specifying_plane fs _ =
     (Invalid_argument "Must specify plane for data read") (fun _ ->
       Tiff.data tiff ro Tiff.Data.Uint8)
 
-let test_load_simple_int8_tiff fs _ =
-  Eio.Path.(with_open_in (fs / "../testdata/uniform_int8_lzw.tiff")) @@ fun r ->
-  let ro = Eio.File.pread_exact r in
+let test_load_simple_int8_tiff _ =
+  Tiff_unix.with_open_in "../testdata/uniform_int8_lzw.tiff" @@ fun ro ->
   let tiff = Tiff.from_file ro in
   let header = Tiff.ifd tiff in
   assert_equal ~printer:Int.to_string ~msg:"Image width" 8
@@ -221,10 +220,8 @@ let test_load_simple_uint32_tiff fs _ =
     (Invalid_argument "datatype not correct for plane") (fun _ ->
       Tiff.data ~window tiff ro Tiff.Data.Int32)
 
-let test_load_simple_float32_tiff fs _ =
-  Eio.Path.(with_open_in (fs / "../testdata/uniform_float32_lzw.tiff"))
-  @@ fun r ->
-  let ro = Eio.File.pread_exact r in
+let test_load_simple_float32_tiff _ =
+  Tiff_unix.with_open_in "../testdata/uniform_float32_lzw.tiff" @@ fun ro ->
   let tiff = Tiff.from_file ro in
   let header = Tiff.ifd tiff in
   assert_equal ~printer:Int.to_string ~msg:"Image width" 10
@@ -327,13 +324,13 @@ let suite fs =
          >:: test_read_single_plane_fails_when_specifying_plane fs;
          "Test fail reading from multi-plane TIFF if plane not specified"
          >:: test_read_multi_plane_fails_when_without_specifying_plane fs;
-         "Test load simple int8 tiff" >:: test_load_simple_int8_tiff fs;
+         "Test load simple int8 tiff" >:: test_load_simple_int8_tiff;
          "Test load simple uint8 tiff" >:: test_load_simple_uint8_tiff fs;
          "Test load simple int16 tiff" >:: test_load_simple_int16_tiff fs;
          "Test load simple uint16 tiff" >:: test_load_simple_uint16_tiff fs;
          "Test load simple int32 tiff" >:: test_load_simple_int32_tiff fs;
          "Test load simple uint32 tiff" >:: test_load_simple_uint32_tiff fs;
-         "Test load simple float32 tiff" >:: test_load_simple_float32_tiff fs;
+         "Test load simple float32 tiff" >:: test_load_simple_float32_tiff;
          "Test load simple float64 tiff" >:: test_load_simple_float64_tiff fs;
          "Test load three channel tiff" >:: uniform_rgb_uint8_lzw fs;
        ]


### PR DESCRIPTION
It would be good to offer a non-Eio backend (see #27). Users can add `tiff.unix` to get a Unix (macOS/Linux) backend.

cc @mdales